### PR TITLE
Enums Exports

### DIFF
--- a/src/Enums.js
+++ b/src/Enums.js
@@ -1,4 +1,8 @@
-export const AccountType = {
+// Disable undeclared variable check on 'exports'
+/*global exports:true*/
+/*eslint no-undef: "error"*/
+
+exports.AccountType = {
     UMBRELLA: 'umbrella',
     DONATING_AGENCY_MEMBER: 'donating_agency_member',
     RECEIVING_AGENCY : 'receiving_agency',
@@ -8,11 +12,11 @@ export const AccountType = {
 // For now (as of 3/5/2018), the only umbrella
 // account type is school (eg UW). In the future,
 // there could be other types such as corporate.
-export const UmbrellaType = {
+exports.UmbrellaType = {
     SCHOOL: 'school',
 };
 
-export const PageContent = {
+exports.PageContent = {
     ASSIGN_VOLUNTEERS: 'Assign Volunteers',
     CALENDAR: 'Calendar',
     DIRECTORY: 'Directory',
@@ -21,19 +25,19 @@ export const PageContent = {
     SETTINGS: 'Settings'
 };
 
-export const RequestDurationType = {
+exports.RequestDurationType = {
     DATE: 'date',  // an end date
     RECUR: 'num_recurrences'  // number of recurrences
 };
 
-export const RequestRepeatType = {
+exports.RequestRepeatType = {
     WEEKLY: 'weekly',
     BIWEEKLY: 'biweekly', // every other week
     MONTHLY: 'monthly',
     // TODO Nth weekday of month
 };
 
-export const NotificationType = {
+exports.NotificationType = {
     NEW_ACCOUNT: 'new_account',
     RECURRING_PICKUP_REQUEST: 'recurring_pickup_request',
     RECURRING_PICKUP_CONFIRMED: 'recurring_pickup_confirmed',


### PR DESCRIPTION
Cloud Functions don't support ES6 imports/exports:

- Changed exports in `Enums.js` to allow it to be shared by both React frontend and Cloud Functions server backend.
- Disabled undeclared variable check in `Enums.js`